### PR TITLE
주석 오류 수정

### DIFF
--- a/language-guide/03-strings-and-characters.md
+++ b/language-guide/03-strings-and-characters.md
@@ -215,7 +215,7 @@ Swift의 네이티브 문자열 타입은 유니코드 스칼라 값으로 만�
 ```swift
   let unusualMenagerie = "Koala 🐨, Snail 🐌, Penguin 🐧, Dromedary 🐪"
   print("unusualMenagerie has \(unusualMenagerie.count) characters")
-  // "unusualMenagerie의 문자는 40개"
+  // Prints "unusualMenagerie has 40 characters"
 ```
 
 **문자열의 접근과 수정**


### PR DESCRIPTION
해당 위치의 주석은 print문에 대한 출력 결과를 다뤄야 하는데, 코드의 설명에 대한 내용이라서 수정 요청을 합니다. 